### PR TITLE
Add dark-mode colors

### DIFF
--- a/htmldiff.pl
+++ b/htmldiff.pl
@@ -312,22 +312,24 @@ sub splitit {
 	my $inelement=0;
 	my $retval = "";
 	my $styles = q(<style type='text/css'>
-.diff-old-a {
-  font-size: smaller;
-  color: red;
+:root {
+	--diff-old-bg: #fbb;
+	--diff-chg-bg: lime;
+	--diff-new-bg: yellow;
 }
+@media (prefers-color-scheme: dark) {
+:root {
+	--diff-old-bg: #a11;
+	--diff-chg-bg: #191;
+	--diff-new-bg: #441;
+}}
 
-.diff-new { background-color: yellow; }
-.diff-chg { background-color: lime; }
-.diff-new:before,
-.diff-new:after
-    { content: "\2191" }
-.diff-chg:before, .diff-chg:after
-    { content: "\2195" }
-.diff-old { text-decoration: line-through; background-color: #FBB; }
-.diff-old:before,
-.diff-old:after
-    { content: "\2193" }
+.diff-new { background-color: var(--diff-new-bg); }
+.diff-new:before, .diff-new:after { content: "\2191" }
+.diff-chg { background-color: var(--diff-chg-bg); }
+.diff-chg:before, .diff-chg:after { content: "\2195" }
+.diff-old { text-decoration: line-through; background-color: var(--diff-old-bg); }
+.diff-old:before, .diff-old:after { content: "\2193" }
 </style>
 <script src="https://w3c.github.io/htmldiff-nav/index.js"></script>);
 	if ($opt_t) {


### PR DESCRIPTION
Upon adding darkmode support to WHATWG specs, it was discovered that PR Preview links for WHATWG specs had unreadable diffs, since the color choices in this tool were assuming dark text.

I've abstracted those colors into variables, and assigned them appropriately. Light mode colors were kept as-is. I hand-chose some reasonable-looking darkmode colors, assuming a white or light gray text color.

I also slightly reformatted the CSS for consistency; the three sets of rules for new/chg/old had parallel structure but were each organized differently, for no apparent reason.

Finally, I removed the lingering `.diff-old-a` class. That was no longer used; it appears that the code that would emit it is commented out, on line 174 of `htmldiff.pl`. I can restore this if necessary.