### PR TITLE
Conditionalize the darkmode colors on the spec declaring that it's darkmode capable. Fixes #12

### DIFF
--- a/htmldiff.pl
+++ b/htmldiff.pl
@@ -318,7 +318,7 @@ sub splitit {
 	--diff-new-bg: yellow;
 }
 @media (prefers-color-scheme: dark) {
-:root {
+:root:has(meta[name="color-scheme"][content ~= "dark"]) {
 	--diff-old-bg: #a11;
 	--diff-chg-bg: #191;
 	--diff-new-bg: #441;

--- a/htmldiff.pl
+++ b/htmldiff.pl
@@ -318,7 +318,7 @@ sub splitit {
 	--diff-new-bg: yellow;
 }
 @media (prefers-color-scheme: dark) {
-:root:has(meta[name="color-scheme"][content ~= "dark"]) {
+:root:has(meta[name="color-scheme"][content*="dark"]) {
 	--diff-old-bg: #a11;
 	--diff-chg-bg: #191;
 	--diff-new-bg: #441;


### PR DESCRIPTION
Bikeshed's latest release now ensures that documents get a `<meta name=color-scheme>` if they support darkmode (rather, if they fail to opt-out via `Dark Mode: no`), so this should successfully catch all new Bikeshedded things (and specifically, all the tooling that autogenerates previews, since that stays on latest Bikeshed). In the meantime, specs that don't have this will go back to just using lightmode diff colors.